### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/scripts/log-summary
+++ b/scripts/log-summary
@@ -15,4 +15,4 @@ for line in sys.stdin:
         color = GREEN
     elif "FAIL" in line or "error:" in line:
         color = RED
-    print "%s%s%s" % (color, line, RESET)
+    print("%s%s%s" % (color, line, RESET))


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.