### PR TITLE
ci: Ignore the build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /*.sublime-workspace
 
 /archives
+/build
 
 /ansible/gameplay.retry
 


### PR DESCRIPTION
Since the build directory should no longer be checked into the source tree, it should be ignored.