### PR TITLE
ci: Release master builds automatically

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,10 @@ jobs:
       run: scripts/install-dependencies.sh
 
     - name: Build release
-      run: scripts/gameplay build settings/release.json
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TRY_RELEASE: ${{ github.ref == 'refs/heads/main' }}
+      run: scripts/build.sh
 
     - name: Save artifacts
       uses: actions/upload-artifact@v1

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 # unless otherwise overridden by more specific contexts.
 [build]
   publish = "build/"
-  command = "scripts/build.sh --prune-tags"
+  command = "scripts/build.sh --install-dependencies --prune-tags"
 
 [context.deploy-preview]
-  command = "scripts/build.sh --prune-tags --preview"
+  command = "scripts/build.sh --install-dependencies --prune-tags --preview"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,8 +25,9 @@ set -x
 set -u
 
 SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-
 CHANGES_SCRIPT="${SCRIPTS_DIRECTORY}/changes/changes"
+
+TRY_RELEASE_BOUND=${TRY_RELEASE:-false}
 
 # Process the command line arguments.
 POSITIONAL=()
@@ -89,6 +90,6 @@ fi
 
 # Attempt to create a version tag and publish a GitHub release.
 # This fails quietly if there's no release to be made.
-if $RELEASE || $TRY_RELEASE ; then
+if $RELEASE || $TRY_RELEASE_BOUND ; then
     "$CHANGES_SCRIPT" release --skip-if-empty --push --command 'gh release create $CHANGES_TAG --title "$CHANGES_TITLE" --notes "$CHANGES_NOTES"' "$@"
 fi


### PR DESCRIPTION
This change updates the GitHub Actions workflow to use the same build script as Netlify (with slightly different flags), and updates that script so that it can perform releases, conditional on the TRY_RELEASE environment variable (or --release flag). The workflow is updated to set TRY_RELEASE to true on master builds.