### PR TITLE
docs: Move the changelog into a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Game Play
-=========
+# Game Play Color
 
 [![Build](https://github.com/gameplaycolor/gameplaycolor/actions/workflows/main.yml/badge.svg)](https://github.com/gameplaycolor/gameplaycolor/actions/workflows/main.yml)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/6b57f8f0-fdc2-4372-a0ad-d7c8cb35f612/deploy-status)](https://app.netlify.com/sites/gameplaycolor/deploys)
@@ -8,8 +7,7 @@ A JavaScript Game Boy and Game Boy Color emulator for iOS, based on the [GameBoy
 
 If you just want to play Game Play, you can find it online at [https://gameplaycolor.com](https://gameplaycolor.com).
 
-Dependencies
-------------
+## Dependencies
 
 Check out the project, update the submodules, install the brew-based dependencies, and install the additional Python dependencies:
 
@@ -26,8 +24,7 @@ It may be necessary to install pipenv as follows:
 pip3 install pipenv
 ```
 
-Building
---------
+## Building
 
 Game Play is built using a custom Python build script which inlines and minifies HTML, CSS and JavaScript, and binds in the settings for a given deployment.
 
@@ -39,150 +36,7 @@ scripts/gameplay build settings/release.json
 
 The build will be created in the `build` directory, and a corresponding *.tar.gz will be created in `archives`, tagged with the git sha and settings name (e.g., `build-168bd9d0d8d309a1efb1983bd61ec34ff22951b5-release.tar.gz`).
 
-Changelog
----------
-
-### Version 2.4.0
-
-- Update from @nickydraz to use IndexedDB to support iOS 13.
-
-### Version 2.3.8
-
-- Fix audio playback on iOS 11.
-
-### Version 2.3.7
-
-- Updating Google Drive authentication.
-
-### Version 2.3.6
-
-- Improving the first run messaging.
-
-### Version 2.3.5
-
-- Fixing the icon on the sign in page.
-
-### Version 2.3.4
-
-- Fixing some crashes.
-
-### Version 2.3.3
-
-- Re-enable crash reporting.
-- Bug fixes.
-
-### Version 2.3.2
-
-- Fixing a small bug in artwork lookup.
-- Minor improvements to logging.
-
-### Version 2.3.1
-
-- Adding a mechanism to email logs.
-
-### Version 2.3.0
-
-- New improved game library.
-
-### Version 2.2.3
-
-- Catching up to upstream GameBoy-Online.
-- Some UI improvements.
-
-### Version 2.2.2
-
-- Don't animate the console when restoring games.
-- Temporarily disabling button animations to improve audio performance.
-
-### Version 2.2.1
-
-- New in-game menu.
-- Menu option for resetting the current game.
-- Menu option for Zelda fans: A + B + Select + Start.
-
-### Version 2.2.0
-
-- Support for diagonal directions using the d-pad.
-- Improved scrolling in the game library.
-
-### Version 2.1.7
-
-- Setting for console color.
-- Work-around for audio playback issues on iPhone 6.
-
-### Version 2.1.6
-
-- Adding support for different emulation speeds.
-
-### Version 2.1.5
-
-- Adding scrolling to the settings dialog on small screens.
-- Adding the version to the settings dialog.
-
-### Version 2.1.4
-
-- Moving the account sign out and 'Say Thanks' into a new settings dialog.
-- Adding the option to disable sound; use this to listen to your own music!
-
-### Version 2.1.3
-
-- Fixing early Google Drive session expiry.
-- Minor UI tweaks.
-
-### Version 2.0.13
-
-- Show release notes when informing users about updates.
-- Only display errors if no update is available.
-
-### Version 2.0.12
-
-- Improving guards against loading corrupt ROMs.
-
-### Version 2.0.11
-
-- Correcting the characters used on the d-pad and in the 'Say Thanks' link on iOS 8.3.
-
-### Version 2.0.10
-
-- Adding the application version, screen size and the user agent string into the logs.
-
-### Version 2.0.9
-
-- Improved logging.
-- Better error handling of missing ROMs.
-
-### Version 2.0.8
-
-- Improving information available in crash log emails.
-- Fixing some bugs which resulted in an attmept to play and save ROMs that had failed to download.
-- Introduced a recovery mechanism for the above scenario.
-- Improved debugging tools.
-
-### Version 2.0.7
-
-- Layout support for iPhone 4 and 4S.
-
-### Version 2.0.6
-
-- Changing the default error handler to ignore errors from cross-origin scripts.
-
-### Version 2.0.5
-
-- Fixed crash when inspecting Google Drive files with no extension.
-- Preventing application from running if the user cancels database creation.
-- Fixed crash when Google Drive returned an empty response.
-- Fixed crash due to incorrectly named logging call.
-
-### Version 2.0.0
-
-- Initial release of Game Play.
-
-### Version 1.0.0
-
-- Initial release of Game Play.
-
-Thanks
-------
+## Thanks
 
 Many thanks to:
 
@@ -192,15 +46,13 @@ Many thanks to:
 - [Paul Ledger](http://www.flexicoder.com) for suggesting the name 'Game Play'.
 - [Pavlos Vinieratos](https://github.com/pvinis) for help and suggestions testing early builds.
 
-Legal
------
+## Legal
 
 1. Game Boy and Game Boy Color are trademarks of Nintendo Co., Ltd.. All rights reserved.
 2. Downloading copied ROMs is illegal: only use images you have created from ROMs you own yourself.
 3. InSeven Limited is an independent software company and is in no way affiliated with Nintendo Co., Ltd..
 
-License
--------
+## License
 
 Game Play and its [dependencies](#third-party-sources) are licensed under the MIT license. See [LICENSE](LICENSE) for more details.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,140 @@
+# Changelog
+
+## Version 2.4.0
+
+- Update from @nickydraz to use IndexedDB to support iOS 13.
+
+## Version 2.3.8
+
+- Fix audio playback on iOS 11.
+
+## Version 2.3.7
+
+- Updating Google Drive authentication.
+
+## Version 2.3.6
+
+- Improving the first run messaging.
+
+## Version 2.3.5
+
+- Fixing the icon on the sign in page.
+
+## Version 2.3.4
+
+- Fixing some crashes.
+
+## Version 2.3.3
+
+- Re-enable crash reporting.
+- Bug fixes.
+
+## Version 2.3.2
+
+- Fixing a small bug in artwork lookup.
+- Minor improvements to logging.
+
+## Version 2.3.1
+
+- Adding a mechanism to email logs.
+
+## Version 2.3.0
+
+- New improved game library.
+
+## Version 2.2.3
+
+- Catching up to upstream GameBoy-Online.
+- Some UI improvements.
+
+## Version 2.2.2
+
+- Don't animate the console when restoring games.
+- Temporarily disabling button animations to improve audio performance.
+
+## Version 2.2.1
+
+- New in-game menu.
+- Menu option for resetting the current game.
+- Menu option for Zelda fans: A + B + Select + Start.
+
+## Version 2.2.0
+
+- Support for diagonal directions using the d-pad.
+- Improved scrolling in the game library.
+
+## Version 2.1.7
+
+- Setting for console color.
+- Work-around for audio playback issues on iPhone 6.
+
+## Version 2.1.6
+
+- Adding support for different emulation speeds.
+
+## Version 2.1.5
+
+- Adding scrolling to the settings dialog on small screens.
+- Adding the version to the settings dialog.
+
+## Version 2.1.4
+
+- Moving the account sign out and 'Say Thanks' into a new settings dialog.
+- Adding the option to disable sound; use this to listen to your own music!
+
+## Version 2.1.3
+
+- Fixing early Google Drive session expiry.
+- Minor UI tweaks.
+
+## Version 2.0.13
+
+- Show release notes when informing users about updates.
+- Only display errors if no update is available.
+
+## Version 2.0.12
+
+- Improving guards against loading corrupt ROMs.
+
+## Version 2.0.11
+
+- Correcting the characters used on the d-pad and in the 'Say Thanks' link on iOS 8.3.
+
+## Version 2.0.10
+
+- Adding the application version, screen size and the user agent string into the logs.
+
+## Version 2.0.9
+
+- Improved logging.
+- Better error handling of missing ROMs.
+
+## Version 2.0.8
+
+- Improving information available in crash log emails.
+- Fixing some bugs which resulted in an attmept to play and save ROMs that had failed to download.
+- Introduced a recovery mechanism for the above scenario.
+- Improved debugging tools.
+
+## Version 2.0.7
+
+- Layout support for iPhone 4 and 4S.
+
+## Version 2.0.6
+
+- Changing the default error handler to ignore errors from cross-origin scripts.
+
+## Version 2.0.5
+
+- Fixed crash when inspecting Google Drive files with no extension.
+- Preventing application from running if the user cancels database creation.
+- Fixed crash when Google Drive returned an empty response.
+- Fixed crash due to incorrectly named logging call.
+
+## Version 2.0.0
+
+- Initial release of Game Play.
+
+## Version 1.0.0
+
+- Initial release of Game Play.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+This file is no longer being updated. Check the [GitHub Releases page](https://github.com/gameplaycolor/gameplaycolor/releases) for up to date releases and changes.
+
 ## Version 2.4.0
 
 - Update from @nickydraz to use IndexedDB to support iOS 13.


### PR DESCRIPTION
Since the project is now using semantic versioning for automatic releases, the changelog isn’t automatically being updated (release notes are added to the GitHub releases page instead). Given this, this change moves the now-static changelog out of the release notes and into a separate file for reference.