### PR TITLE
fix: Support for iPadOS

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -303,9 +303,7 @@ Promise.prototype.always = function(onAlways) {
 
   $(document).ready(function() {
 
-    var iPhone = (navigator.userAgent.indexOf("iPhone OS") !== -1);
-    var iPad = (navigator.userAgent.indexOf("iPad") !== -1);
-    if ((window.navigator.standalone === true && (iPhone || iPad))) {
+    if (window.navigator.standalone === true) {
 
       bootstrap();
 


### PR DESCRIPTION
Since Safari on iPadOS has started pretending to be running on a Macintosh, the explicit iPad checks no longer work and incorrectly prevent Game Play from running on iPad. This change relaxes the device specific checks. It is an acceptable (perhaps even desirable) side effect that this may enable Game Play on other devices.